### PR TITLE
Fix REST API method 'discover_cluster'

### DIFF
--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -99,10 +99,10 @@ def discover_cluster():
     # At this point only OpenStack-based discovery is implemented.
     if discovery_method == constants.OPENSTACK:
         sess = session.Session(auth=v2.Password(
-            username=request.args.get('username'),
-            password=request.args.get('password'),
-            tenant_name=request.args.get('tenant_name'),
-            auth_url=request.args.get('auth_url')))
+            username=request.form.get('username'),
+            password=request.form.get('password'),
+            tenant_name=request.form.get('tenant_name'),
+            auth_url=request.form.get('auth_url')))
         cluster_discovery = discover.OpenStackServiceDiscovery(sess)
         try:
             services = cluster_discovery.discover()
@@ -113,7 +113,7 @@ def discover_cluster():
             )
             return resp
 
-        new_cluster = db_api.create_cluster(request.args.get('cluster_name'),
+        new_cluster = db_api.create_cluster(request.form.get('cluster_name'),
                                             constants.UNDEFINED,
                                             constants.NOT_READY_FOR_UPGRADE)
         host_service_map = defaultdict(list)

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -1,8 +1,11 @@
 import json
+from keystoneauth1 import exceptions
 import mock
 import sys
 import unittest
+
 from kostyor.rest_api import app
+from kostyor.common import constants
 sys.modules['kostyor.conf'] = mock.Mock()
 
 
@@ -11,6 +14,14 @@ class KostyorRestAPITest(unittest.TestCase):
     def setUp(self):
         self.app = app.test_client()
         self.cluster_id = 123
+        self.discover_cluster_request_data = {
+            'method': 'openstack',
+            'cluster_name': 'test-cluster',
+            'username': 'admin',
+            'password': 'qwerty',
+            'tenant_name': 'admin',
+            'auth_url': 'http://9.9.9.9',
+        }
 
     @mock.patch('kostyor.db.api.get_cluster_status')
     def test_get_cluster_status(self, fake_db_get_cluster_status):
@@ -239,3 +250,84 @@ class KostyorRestAPITest(unittest.TestCase):
         fake_inventory_rollback_upgrade.return_value = 0
         res = self.app.put('/upgrade-rollback/{}'.format(self.cluster_id))
         self.assertEqual(200, res.status_code)
+
+    @mock.patch('keystoneauth1.identity.v2.Password')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch(
+        'kostyor.inventory.discover.OpenStackServiceDiscovery.discover')
+    @mock.patch('kostyor.db.api.create_cluster')
+    @mock.patch('kostyor.db.api.create_host')
+    @mock.patch('kostyor.db.api.create_service')
+    def test_discover_cluster_openstack_method_success(self,
+                                                       fake_create_service,
+                                                       fake_create_host,
+                                                       fake_create_cluster,
+                                                       fake_discover,
+                                                       fake_session,
+                                                       fake_password):
+        password_mock = mock.Mock()
+        fake_password.return_value = password_mock
+        fake_discover.return_value = [('1.2.3.4', 'nova-api'), ]
+        cluster = {
+            'id': 'cluster-id',
+            'name': 'test-cluster',
+            'version': 'mitaka',
+            'status': 'READY_FOR_UPGRADE',
+        }
+        fake_create_cluster.return_value = cluster
+        fake_create_host.return_value = {
+            'id': 'host-id',
+            'name': '1.2.3.4',
+            'cluster_id': 'cluster-id',
+        }
+
+        res = self.app.post('/discover-cluster',
+                            data=self.discover_cluster_request_data)
+        decoded_res = res.data.decode('utf-8')
+        data = json.loads(decoded_res)
+
+        self.assertEqual(201, res.status_code)
+        self.assertEqual(cluster, data)
+        fake_password.assert_called_once_with(username='admin',
+                                              password='qwerty',
+                                              tenant_name='admin',
+                                              auth_url='http://9.9.9.9')
+        fake_session.assert_called_once_with(auth=password_mock)
+        fake_discover.assert_called_once_with()
+        fake_create_cluster.assert_called_once_with(
+            'test-cluster',
+            constants.UNDEFINED,
+            constants.NOT_READY_FOR_UPGRADE)
+        fake_create_host.assert_called_once_with('1.2.3.4', 'cluster-id')
+        fake_create_service.assert_called_once_with(
+            'nova-api',
+            'host-id',
+            constants.NOT_READY_FOR_UPGRADE)
+
+    def test_discover_cluster_unsupported_method_error_response(self):
+        res = self.app.post('/discover-cluster',
+                            data={'method': 'unsupported'})
+        self.assertEqual(404, res.status_code)
+
+    @mock.patch('keystoneauth1.identity.v2.Password')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch(
+        'kostyor.inventory.discover.OpenStackServiceDiscovery.discover')
+    def test_discover_cluster_discovery_failed_error_response(self,
+                                                              fake_discover,
+                                                              fake_session,
+                                                              fake_password):
+        password_mock = mock.Mock()
+        fake_password.return_value = password_mock
+        fake_discover.side_effect = exceptions.Unauthorized()
+
+        res = self.app.post('/discover-cluster',
+                            data=self.discover_cluster_request_data)
+
+        self.assertEqual(401, res.status_code)
+        fake_password.assert_called_once_with(username='admin',
+                                              password='qwerty',
+                                              tenant_name='admin',
+                                              auth_url='http://9.9.9.9')
+        fake_session.assert_called_once_with(auth=password_mock)
+        fake_discover.assert_called_once_with()


### PR DESCRIPTION
REST API method 'discover_cluster' cannot get request data - auth_url, username, password, etc. Need to fix this issue and to cover 'discover_cluster' with unit tests.