### PR TITLE
Use .gitignore from cookiecutter project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,58 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg*
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+cover/
+.coverage*
+!.coveragerc
 .tox
+nosetests.xml
+.testrepository
+.venv
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+doc/build
+
+# pbr generates these
 AUTHORS
 ChangeLog
-kostyor.egg-info/
-doc/build
-.testrepository
-.eggs
-build
-dist
+
+# Editors
+*~
+.*.swp
+.*sw?
+
+# Files created by releasenotes build
+releasenotes/build


### PR DESCRIPTION
So far `.gitignore` doesn't cover a lot of temporary files occured
developing Python project. For instance, it doesn't cover *.pyc files
and swap/backup files of popular text editors.

This commit uses `.gitignore` from OpenStack cookiecutter project that
covers all popular cases.

[1] https://github.com/openstack-dev/cookiecutter