### PR TITLE
Fix /discovery-methods endpoint

### DIFF
--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -40,8 +40,8 @@ def get_upgrade(upgrade_id):
     return u_task.to_dict()
 
 
-def get_discovery_methods(db_session):
-    return {'discovery_methods': constants.DISCOVERY_METHODS}
+def get_discovery_methods():
+    return constants.DISCOVERY_METHODS
 
 
 def get_upgrade_versions(cluster_id):

--- a/kostyor/tests/unit/test_db_api.py
+++ b/kostyor/tests/unit/test_db_api.py
@@ -70,3 +70,8 @@ class DbApiTestCase(base.BaseTestCase):
         result = db_api.get_cluster(cluster['id'])
 
         self.assertEqual(update['name'], result['name'])
+
+    def test_discovery_methods(self):
+        methods = db_api.get_discovery_methods()
+        # we don't care about ordering here, so let's compare sorted arrays
+        self.assertEqual(sorted(methods), sorted([constants.OPENSTACK]))


### PR DESCRIPTION
Currently there're two issues with that endpoint:

* It uses DBAPI.get_discovery_methods() without arguments but it
  does receive one.

* It expects DBAPI.get_discovery_methods() to return a list of
  supported discovery methods, but it returns a dictionary instead.

The fix for the first one is to get rid of unused argument, and for the
second one - return a list instead of dictionary. The funny thing is, we
have a correct mock in tests.. it's a production code that's  broken.