### PR TITLE
Introduce Flask-RESTful with Cluster resource

### DIFF
--- a/contrib/openapi.yml
+++ b/contrib/openapi.yml
@@ -85,11 +85,12 @@ paths:
           description: Cluster not found.
           schema:
             $ref: '#/definitions/Error'
-  /clusters/{id}/upgrades:
+  /upgrades:
     get:
-      summary: List Upgrade Tasks of Clusters
+      summary: List Upgrade Tasks
       parameters:
-        - name: id
+        - name: cluster_id
+          in: query
           type: string
           pattern: *UUID_PATTERN
           required: true
@@ -103,20 +104,28 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Upgrade'
-        404:
-          description: Cluster not found.
-          schema:
-            $ref: '#/definitions/Error'
     post:
       summary: Start Cluster Upgrade
       parameters:
-        - name: id
-          type: string
-          pattern: *UUID_PATTERN
-          required: true
-          in: path
-          description: |
-            Unique identifier representing the specific cluster.
+        - name: payload
+          in: body
+          schema:
+            type: object
+            required:
+              - cluster_id
+              - to_version
+            properties:
+              cluster_id:
+                type: string
+                pattern: *UUID_PATTERN
+                description: An OpenStack cluster to start upgrade on.
+              to_version:
+                type: string
+                enum: &OPENSTACK_VERSIONS
+                  - unknown
+                  - liberty
+                  - mitaka
+                  - newton
       responses:
         202:
           description: A task instance to track the progress.
@@ -130,7 +139,7 @@ paths:
           description: Cluster not found.
           schema:
             $ref: '#/definitions/Error'
-  /clusters/{id}/upgrades/{upgrade_id}:
+  /upgrades/{id}:
     get:
       summary: Show Upgrade Task
       parameters:
@@ -159,14 +168,27 @@ paths:
           required: true
           in: path
           description: |
-            Unique identifier representing the specific cluster.
-        - name: upgrade_id
-          type: string
-          pattern: *UUID_PATTERN
-          required: true
-          in: path
-          description: |
             Unique identifier representing the specific upgrade task.
+        - name: payload
+          in: body
+          schema:
+            type: object
+            required:
+              - cluster_id
+              - action
+            properties:
+              cluster_id:
+                type: string
+                pattern: *UUID_PATTERN
+                description: An OpenStack cluster to start upgrade on.
+              action:
+                type: string
+                enum:
+                  - pause
+                  - continue
+                  - cancel
+                  - rollback
+                description: An action to be executed.
       responses:
         200:
           description: A task instance to track the progress.
@@ -196,11 +218,7 @@ definitions:
         type: string
       version:
         type: string
-        enum: &OPENSTACK_VERSIONS
-          - unknown
-          - liberty
-          - mitaka
-          - newton
+        enum: *OPENSTACK_VERSIONS
       status:
         type: string
         enum: &ENVIRONMENT_STATUSES

--- a/kostyor/common/exceptions.py
+++ b/kostyor/common/exceptions.py
@@ -1,0 +1,26 @@
+class KostyorException(Exception):
+    """Base Kostyor exception to catch 'em all!"""
+
+
+class NotFound(KostyorException):
+    """Base exception for a series of "Not Found" exceptions."""
+
+
+class BadRequest(KostyorException):
+    """Base exception for a series of "Bad Request" exceptions."""
+
+
+class ClusterNotFound(NotFound):
+    """Cluster Not Found"""
+
+
+class ClusterVersionIsUnknown(BadRequest):
+    """Operations is not allowed since cluster version is unknown."""
+
+
+class CannotUpgradeToLowerVersion(BadRequest):
+    """Upgrade operation can be initiated only to higher version."""
+
+
+class UpgradeIsInProgress(BadRequest):
+    """Upgrade operation is in progress."""

--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -4,8 +4,6 @@ import six
 from kostyor.common import constants
 from kostyor.db import models
 
-from six.moves import map
-
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
@@ -104,9 +102,8 @@ def rollback_cluster_upgrade(cluster_id):
 
 
 def get_clusters():
-    return {'clusters': list(map(lambda x: {'id': x.id, 'name': x.name,
-                                            'status': x.status},
-                                 db_session.query(models.Cluster).all()))}
+    # TODO(ikalnitsky): implement pagination in params
+    return [cluster.to_dict() for cluster in db_session.query(models.Cluster)]
 
 
 def create_host(name, cluster_id):

--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -1,7 +1,7 @@
 import datetime
 import six
 
-from kostyor.common import constants
+from kostyor.common import constants, exceptions
 from kostyor.db import models
 
 from sqlalchemy import create_engine
@@ -52,6 +52,26 @@ def create_discovery_method(method):
 
 def create_cluster_upgrade(cluster_id, to_version):
     cluster = db_session.query(models.Cluster).get(cluster_id)
+
+    if cluster is None:
+        raise exceptions.ClusterNotFound(
+            'Cluster "%s" not found.' % cluster_id)
+
+    if cluster.version == constants.UNKNOWN:
+        raise exceptions.ClusterVersionIsUnknown('Cluster version is unknown')
+
+    if cluster.status == constants.UPGRADE_IN_PROGRESS:
+        raise exceptions.UpgradeIsInProgress(
+            'Cluster %s already has an upgrade in progress.' % cluster_id)
+
+    if (constants.OPENSTACK_VERSIONS.index(cluster.version)
+            >= constants.OPENSTACK_VERSIONS.index(to_version)):
+        raise exceptions.CannotUpgradeToLowerVersion(
+            'Upgrade procedure from "%s" to "%s" is not allowed.' % (
+                cluster.version, to_version
+            )
+        )
+
     cluster.status = constants.UPGRADE_IN_PROGRESS
     u_task = models.UpgradeTask()
     u_task.cluster_id = cluster_id
@@ -61,7 +81,7 @@ def create_cluster_upgrade(cluster_id, to_version):
     db_session.add(u_task)
     db_session.commit()
     # TODO(sc68cal) RPC or calls to task broker to start upgrade
-    return {'id': cluster_id, 'status': constants.UPGRADE_IN_PROGRESS}
+    return u_task.to_dict()
 
 
 def cancel_cluster_upgrade(cluster_id):
@@ -104,6 +124,15 @@ def rollback_cluster_upgrade(cluster_id):
 def get_clusters():
     # TODO(ikalnitsky): implement pagination in params
     return [cluster.to_dict() for cluster in db_session.query(models.Cluster)]
+
+
+def get_upgrades(cluster_id=None):
+    query = db_session.query(models.UpgradeTask)
+
+    if cluster_id is not None:
+        query = query.filter_by(cluster_id=cluster_id)
+
+    return [upgrade.to_dict() for upgrade in query]
 
 
 def create_host(name, cluster_id):

--- a/kostyor/resources/__init__.py
+++ b/kostyor/resources/__init__.py
@@ -1,7 +1,10 @@
 from .clusters import Clusters, Cluster
+from .upgrades import Upgrades, Upgrade
 
 
 __all__ = [
     'Clusters',
     'Cluster',
+    'Upgrades',
+    'Upgrade',
 ]

--- a/kostyor/resources/__init__.py
+++ b/kostyor/resources/__init__.py
@@ -1,0 +1,7 @@
+from .clusters import Clusters, Cluster
+
+
+__all__ = [
+    'Clusters',
+    'Cluster',
+]

--- a/kostyor/resources/clusters.py
+++ b/kostyor/resources/clusters.py
@@ -1,0 +1,36 @@
+from flask import request
+from flask_restful import Resource, fields, marshal_with, abort
+
+from kostyor.db import api as db_api
+
+
+_PUBLIC_ATTRIBUTES = {
+    'id': fields.String,
+    'name': fields.String,
+    'status': fields.String,
+    'version': fields.String,
+}
+
+
+class Clusters(Resource):
+
+    @marshal_with({'clusters': fields.Nested(_PUBLIC_ATTRIBUTES)})
+    def get(self):
+        # TODO: get rid of intermediate 'clusters' attribute
+        return {'clusters': db_api.get_clusters()}
+
+
+class Cluster(Resource):
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def get(self, cluster_id):
+        cluster = db_api.get_cluster(cluster_id)
+
+        if not cluster:
+            abort(404, message='Cluster %s not found.' % cluster_id)
+
+        return cluster
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def put(self, cluster_id):
+        return db_api.update_cluster(cluster_id, **request.form)

--- a/kostyor/resources/upgrades.py
+++ b/kostyor/resources/upgrades.py
@@ -1,0 +1,89 @@
+import six
+
+from flask import request
+from flask_restful import Resource, fields, marshal_with, abort
+
+from kostyor.common import constants, exceptions
+from kostyor.db import api as db_api
+
+
+_PUBLIC_ATTRIBUTES = {
+    'id': fields.String,
+    'cluster_id': fields.String,
+    'from_version': fields.String,
+    'to_version': fields.String,
+    'status': fields.String,
+    'upgrade_start_time': fields.DateTime('iso8601'),
+    'upgrade_end_time': fields.DateTime('iso8601'),
+}
+
+
+class Upgrades(Resource):
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def get(self):
+        return db_api.get_upgrades()
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def post(self):
+        payload = request.get_json()
+
+        # TODO: replace a set of validations with some sort of schema
+        #       validation (e.g. cerberus).
+        if 'to_version' not in payload:
+            abort(400, message='"to_version" is a required parameter.')
+        elif payload['to_version'].lower() not in constants.OPENSTACK_VERSIONS:
+            abort(400, message=('Unsupported "to_version": %s' %
+                                payload['to_version']))
+
+        if 'cluster_id' not in payload:
+            abort(400, message='"cluster_id" is a required parameter.')
+
+        try:
+            upgrade = db_api.create_cluster_upgrade(
+                payload['cluster_id'],
+                payload['to_version']
+            )
+        except exceptions.BadRequest as exc:
+            abort(400, message=six.text_type(exc))
+        except exceptions.NotFound as exc:
+            abort(404, message=six.text_type(exc))
+
+        return upgrade, 201
+
+
+class Upgrade(Resource):
+
+    _actions = {
+        'pause': db_api.pause_cluster_upgrade,
+        'continue': db_api.continue_cluster_upgrade,
+        'cancel': db_api.cancel_cluster_upgrade,
+        'rollback': db_api.rollback_cluster_upgrade,
+    }
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def get(self, upgrade_id):
+        upgrade = db_api.get_upgrade(upgrade_id)
+
+        if not upgrade:
+            abort(404, message='Upgrade %s not found.' % upgrade_id)
+
+        return upgrade
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def put(self, upgrade_id):
+        # FIXME: dbapi implicitly retrieves recent upgrade task. i have no
+        #        idea what to do with receied upgrade_id for now. I think
+        #        we should either pass it to DBAPI or use another API design.
+        payload = request.get_json()
+
+        if 'cluster_id' not in payload:
+            abort(400, message='"cluster_id" is a required parameter.')
+
+        if payload['action'] not in self._actions:
+            abort(400, message='Action %s not supported.' % payload['action'])
+
+        fn = self._actions[payload['action']]
+
+        # Would it better to pass upgrade_id instead?
+        return fn(payload['cluster_id'])

--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -9,7 +9,7 @@ from keystoneauth1 import session
 from keystoneauth1.identity import v2
 import six
 
-from kostyor.common import constants
+from kostyor.common import constants, exceptions as kostyor_exc
 from kostyor.inventory import discover
 from kostyor.inventory import upgrades
 from kostyor import resources
@@ -33,6 +33,9 @@ app.config['ERROR_404_HELP'] = False
 api.add_resource(resources.Clusters, '/clusters')
 api.add_resource(resources.Cluster, '/clusters/<cluster_id>')
 
+api.add_resource(resources.Upgrades, '/upgrades')
+api.add_resource(resources.Upgrade, '/upgrades/<upgrade_id>')
+
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
@@ -50,25 +53,12 @@ def generate_response(status, message):
 def get_upgrade_status(cluster_id):
     upgrade = db_api.get_upgrade_by_cluster(cluster_id)
     if upgrade:
-        full_url = url_for('.get_upgrade', upgrade_id=upgrade['id'])
+        full_url = url_for(
+            '.upgrade', cluster_id=cluster_id, upgrade_id=upgrade['id'])
         return redirect(full_url)
     else:
         return generate_response(404, 'Upgrade for cluster %s not found' %
                                  cluster_id)
-
-
-@app.route('/upgrades/<upgrade_id>')
-def get_upgrade(upgrade_id):
-    upgrade = db_api.get_upgrade(upgrade_id)
-    if not upgrade:
-        resp = generate_response(
-            404,
-            'Upgrade %s not found' % upgrade_id
-        )
-        return resp
-
-    resp = jsonify(upgrade)
-    return resp
 
 
 @app.route('/discovery-methods')
@@ -174,30 +164,12 @@ def create_cluster_upgrade(cluster_id):
         return resp
 
     try:
-        cluster = db_api.get_cluster(cluster_id)
-    except Exception as ex:
-        return generate_response(404, ex.message)
-    if cluster['version'] == constants.UNKNOWN:
-        resp = generate_response(400, 'Cluster version is unknown')
-    if (constants.OPENSTACK_VERSIONS.index(cluster['version']) >=
-            constants.OPENSTACK_VERSIONS.index(to_version)):
-        resp = generate_response(
-            400,
-            'Cluster version is the same or newer than %s' % to_version
-        )
-        return resp
+        upgrade = db_api.create_cluster_upgrade(cluster_id, to_version)
 
-    if cluster['status'] == constants.UPGRADE_IN_PROGRESS:
-        return generate_response(400, "Cluster %s already has an upgrade in \
-                                 progress" % cluster_id)
-
-    upgrade = db_api.create_cluster_upgrade(cluster_id, to_version)
-    if not upgrade:
-        resp = generate_response(
-            404,  # TODO probable should fix it later
-            'Failed to create cluster upgrade for cluster: %s' % cluster_id
-        )
-        return resp
+    except kostyor_exc.BadRequest as exc:
+        return generate_response(400, six.text_type(exc))
+    except kostyor_exc.NotFound as exc:
+        return generate_response(404, six.text_type(exc))
 
     resp = jsonify(upgrade)
     resp.status_code = 201

--- a/kostyor/tests/unit/resources/test_clusters.py
+++ b/kostyor/tests/unit/resources/test_clusters.py
@@ -1,0 +1,62 @@
+import json
+
+import mock
+import oslotest.base
+
+from kostyor.common import constants
+from kostyor.rest_api import app
+
+
+class TestClustersEndpoint(oslotest.base.BaseTestCase):
+
+    def setUp(self):
+        super(TestClustersEndpoint, self).setUp()
+        self.app = app.test_client()
+
+    @mock.patch('kostyor.db.api.get_clusters')
+    def test_get_clusters(self, fake_db_get_clusters):
+        expected = [
+            {
+                'id': '11d7f0ab-8aba-4185-a3c3-9604b2ef965e',
+                'name': 'test_a',
+                'status': constants.READY_FOR_UPGRADE,
+                'version': constants.MITAKA,
+            },
+            {
+                'id': '1feef932-e694-48e3-adc9-b85b13a1aa7b',
+                'name': 'test_b',
+                'status': constants.READY_FOR_UPGRADE,
+                'version': constants.NEWTON,
+            },
+        ]
+        fake_db_get_clusters.return_value = expected
+
+        resp = self.app.get('/clusters')
+        self.assertEqual(200, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))['clusters']
+        self.assertEqual(expected, received)
+
+    @mock.patch('kostyor.db.api.get_cluster')
+    def test_get_cluster_status(self, fake_db_get_cluster):
+        expected = {'id': '1feef932-e694-48e3-adc9-b85b13a1aa7b',
+                    'name': 'test',
+                    'status': constants.READY_FOR_UPGRADE,
+                    'version': constants.MITAKA}
+        fake_db_get_cluster.return_value = expected
+
+        resp = self.app.get('/clusters/1feef932-e694-48e3-adc9-b85b13a1aa7b')
+        self.assertEqual(200, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        self.assertEqual(expected, received)
+
+    @mock.patch('kostyor.db.api.get_cluster')
+    def test_get_cluster_404(self, fake_db_get_cluster):
+        fake_db_get_cluster.return_value = None
+
+        resp = self.app.get('/clusters/123')
+        self.assertEqual(404, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        self.assertEqual({'message': 'Cluster 123 not found.'}, received)

--- a/kostyor/tests/unit/resources/test_upgrades.py
+++ b/kostyor/tests/unit/resources/test_upgrades.py
@@ -1,0 +1,260 @@
+import json
+import datetime
+
+import mock
+import oslotest.base
+
+from kostyor.common import constants, exceptions
+from kostyor.rest_api import app
+from kostyor.resources import Upgrade
+
+
+class TestUpgradesEndpoint(oslotest.base.BaseTestCase):
+
+    def setUp(self):
+        super(TestUpgradesEndpoint, self).setUp()
+        self.app = app.test_client()
+        self.fake_upgrade = {
+            'id': 'd8e98946-5a46-4516-9447-d16deb1d878b',
+            'cluster_id': 'edac7d7c-cdfc-4fbe-b194-7b1ffdf21161',
+            'from_version': constants.MITAKA,
+            'to_version': constants.NEWTON,
+            'status': constants.UPGRADE_IN_PROGRESS,
+            'upgrade_start_time': datetime.datetime.utcnow(),
+            'upgrade_end_time': datetime.datetime.utcnow(),
+        }
+
+    def _assert_upgrades(self, db_instance, api_instance):
+        # timestampes in db instance are represented as datetime objects
+        # while in api instance - it's an isoformated string.
+        self.assertEqual(
+            db_instance.pop('upgrade_start_time').isoformat(),
+            api_instance.pop('upgrade_start_time'))
+        self.assertEqual(
+            db_instance.pop('upgrade_end_time').isoformat(),
+            api_instance.pop('upgrade_end_time'))
+
+        # we dealt with timestamps so now we can compare two dicts as is
+        self.assertEqual(db_instance, api_instance)
+
+    @mock.patch('kostyor.db.api.get_upgrades')
+    def test_get_upgrades(self, fake_db_get_upgrades):
+        fake_upgrade_2 = self.fake_upgrade.copy()
+        fake_upgrade_2['id'] = 'eb1ee034-89c2-4b2b-9417-ed514c59dd0f'
+
+        expected = [self.fake_upgrade, fake_upgrade_2]
+        fake_db_get_upgrades.return_value = expected
+
+        resp = self.app.get('/upgrades')
+        self.assertEqual(200, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        for exp, rec in zip(expected, received):
+            self._assert_upgrades(exp, rec)
+
+        fake_db_get_upgrades.assert_called_once_with()
+
+    @mock.patch('kostyor.db.api.get_upgrade')
+    def test_get_upgrade(self, fake_db_get_upgrade):
+        fake_db_get_upgrade.return_value = self.fake_upgrade
+
+        resp = self.app.get('/upgrades/d8e98946-5a46-4516-9447-d16deb1d878b')
+        self.assertEqual(200, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        self._assert_upgrades(self.fake_upgrade, received)
+
+    @mock.patch('kostyor.db.api.get_upgrade')
+    def test_get_upgrade_404(self, fake_db_get_upgrade):
+        fake_db_get_upgrade.return_value = None
+
+        resp = self.app.get('/upgrades/123')
+        self.assertEqual(404, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        self.assertEqual({'message': 'Upgrade 123 not found.'}, received)
+
+    @mock.patch('kostyor.db.api.get_cluster')
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades(self, fake_create_upgrade, _):
+        fake_create_upgrade.return_value = self.fake_upgrade
+
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'cluster_id': self.fake_upgrade['cluster_id'],
+                'to_version': constants.NEWTON,
+            })
+        )
+        self.assertEqual(201, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        self._assert_upgrades(self.fake_upgrade, received)
+
+        fake_create_upgrade.assert_called_once_with(
+            self.fake_upgrade['cluster_id'],
+            constants.NEWTON,
+        )
+
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades_no_to_version(self, fake_create_upgrade):
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'cluster_id': self.fake_upgrade['cluster_id'],
+            })
+        )
+        self.assertEqual(400, resp.status_code)
+
+        error = json.loads(resp.get_data(as_text=True))
+        expected_error = {'message': '"to_version" is a required parameter.'}
+
+        self.assertEqual(expected_error, error)
+        self.assertFalse(fake_create_upgrade.called)
+
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades_no_cluster_id(self, fake_create_upgrade):
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'to_version': constants.NEWTON
+            })
+        )
+        self.assertEqual(400, resp.status_code)
+
+        error = json.loads(resp.get_data(as_text=True))
+        expected_error = {'message': '"cluster_id" is a required parameter.'}
+
+        self.assertEqual(expected_error, error)
+        self.assertFalse(fake_create_upgrade.called)
+
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades_wrong_to_version(self, fake_db_create_upgrade):
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'cluster_id': self.fake_upgrade['cluster_id'],
+                'to_version': 'unsupported-value'
+            })
+        )
+        self.assertEqual(400, resp.status_code)
+
+        error = json.loads(resp.get_data(as_text=True))
+        expected_error = {
+            'message': 'Unsupported "to_version": unsupported-value',
+        }
+        self.assertEqual(expected_error, error)
+        self.assertFalse(fake_db_create_upgrade.called)
+
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades_cluster_not_found(self, fake_create_upgrade):
+        fake_create_upgrade.side_effect = exceptions.ClusterNotFound(
+            'Cluster "edac7d7c-cdfc-4fbe-b194-7b1ffdf21161" not found.'
+        )
+
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'cluster_id': self.fake_upgrade['cluster_id'],
+                'to_version': constants.NEWTON,
+            })
+        )
+        self.assertEqual(404, resp.status_code)
+
+        error = json.loads(resp.get_data(as_text=True))
+        expected_error = {
+            'message':
+                'Cluster "edac7d7c-cdfc-4fbe-b194-7b1ffdf21161" not found.'
+        }
+        self.assertEqual(expected_error, error)
+
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades_cluster_version_unknown(self, fake_create_upgrade):
+        fake_create_upgrade.side_effect = exceptions.ClusterVersionIsUnknown(
+            'Cluster version is unknown.'
+        )
+
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'cluster_id': self.fake_upgrade['cluster_id'],
+                'to_version': constants.NEWTON,
+            })
+        )
+        self.assertEqual(400, resp.status_code)
+
+        error = json.loads(resp.get_data(as_text=True))
+        expected_error = {
+            'message': 'Cluster version is unknown.'
+        }
+        self.assertEqual(expected_error, error)
+
+    @mock.patch('kostyor.db.api.create_cluster_upgrade')
+    def test_post_upgrades_cluster_lower_version(self, fake_create_upgrade):
+        fake_create_upgrade.side_effect = \
+            exceptions.CannotUpgradeToLowerVersion(
+                'Upgrade procedure from "mitaka" to "libery" is not allowed.'
+            )
+
+        resp = self.app.post(
+            '/upgrades',
+            content_type='application/json',
+            data=json.dumps({
+                'cluster_id': self.fake_upgrade['cluster_id'],
+                'to_version': constants.LIBERTY
+            })
+        )
+        self.assertEqual(400, resp.status_code)
+
+        error = json.loads(resp.get_data(as_text=True))
+        expected_error = {
+            'message':
+                'Upgrade procedure from "mitaka" to "libery" is not allowed.',
+        }
+        self.assertEqual(expected_error, error)
+
+    def _make_put_upgrade(self, action):
+        action_fn = mock.Mock(return_value=self.fake_upgrade)
+        with mock.patch.dict(Upgrade._actions, {action: action_fn}):
+            resp = self.app.put(
+                '/upgrades/d8e98946-5a46-4516-9447-d16deb1d878b',
+                content_type='application/json',
+                data=json.dumps({
+                    'cluster_id': self.fake_upgrade['cluster_id'],
+                    'action': action,
+                })
+            )
+            self.assertEqual(200, resp.status_code)
+            action_fn.assert_called_once_with(
+                'edac7d7c-cdfc-4fbe-b194-7b1ffdf21161')
+            return resp
+
+    def test_put_upgrade_cancel(self):
+        resp = self._make_put_upgrade('cancel')
+
+        received = json.loads(resp.get_data(as_text=True))
+        self._assert_upgrades(self.fake_upgrade, received)
+
+    def test_put_upgrade_pause(self):
+        resp = self._make_put_upgrade('pause')
+
+        received = json.loads(resp.get_data(as_text=True))
+        self._assert_upgrades(self.fake_upgrade, received)
+
+    def test_put_upgrade_continue(self):
+        resp = self._make_put_upgrade('continue')
+
+        received = json.loads(resp.get_data(as_text=True))
+        self._assert_upgrades(self.fake_upgrade, received)
+
+    def test_put_upgrade_rollback(self):
+        resp = self._make_put_upgrade('rollback')
+
+        received = json.loads(resp.get_data(as_text=True))
+        self._assert_upgrades(self.fake_upgrade, received)

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -29,22 +29,6 @@ class KostyorRestAPITest(unittest.TestCase):
             'cluster_id': '1234'
         }
 
-    @mock.patch('kostyor.db.api.get_cluster')
-    def test_get_cluster_status(self, fake_db_get_cluster):
-        expected = {'status': 'done', 'name': 'tmp', 'id': '123'}
-        fake_db_get_cluster.return_value = expected
-        res = self.app.get('/clusters/{}'.format(self.cluster_id))
-        self.assertEqual(200, res.status_code)
-        data = res.data.decode('utf-8')
-        received = json.loads(data)
-        self.assertEqual(expected, received)
-
-    @mock.patch('kostyor.db.api.get_cluster')
-    def test_get_cluster_404(self, fake_db_get_cluster):
-        fake_db_get_cluster.return_value = None
-        res = self.app.get('/clusters/{}'.format(self.cluster_id))
-        self.assertEqual(404, res.status_code)
-
     @mock.patch('kostyor.db.api.get_upgrade')
     def test_get_upgrade_status(self, fake_db_get_upgrade):
         expected = {'status': 'status',

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -6,7 +6,7 @@ import unittest
 
 from kostyor.db import api as db_api
 from kostyor.rest_api import app
-from kostyor.common import constants
+from kostyor.common import constants, exceptions as kostyor_exc
 sys.modules['kostyor.conf'] = mock.Mock()
 
 
@@ -28,17 +28,6 @@ class KostyorRestAPITest(unittest.TestCase):
             'name': 'hostname_1',
             'cluster_id': '1234'
         }
-
-    @mock.patch('kostyor.db.api.get_upgrade')
-    def test_get_upgrade_status(self, fake_db_get_upgrade):
-        expected = {'status': 'status',
-                    'id': '123'}
-        fake_db_get_upgrade.return_value = expected
-        res = self.app.get('/upgrades/{}'.format(self.cluster_id))
-        self.assertEqual(200, res.status_code)
-        data = res.data.decode('utf-8')
-        received = json.loads(data)
-        self.assertEqual(expected, received)
 
     @mock.patch('kostyor.db.api.get_upgrade_by_cluster')
     def test_get_upgrade_status_404(self, fake_db_get_upgrade_by_cluster):
@@ -87,29 +76,18 @@ class KostyorRestAPITest(unittest.TestCase):
         self.assertEqual(expected, received)
 
     @mock.patch('kostyor.db.api.create_cluster_upgrade')
-    @mock.patch('kostyor.db.api.get_cluster')
-    def test_create_cluster_upgrade_404(self,
-                                        fake_get_cluster,
-                                        fake_db_create_cluster_upgrade):
-        fake_db_create_cluster_upgrade.return_value = None
-        fake_get_cluster.return_value = {'version': 'liberty', 'status':
-                                         constants.READY_FOR_UPGRADE}
+    def test_create_cluster_upgrade_404(self, fake_db_create_cluster_upgrade):
+        fake_db_create_cluster_upgrade.side_effect = \
+            kostyor_exc.ClusterNotFound('cluster not found')
         res = self.app.post('/upgrade-cluster/{}'.format(self.cluster_id),
                             data={'version': 'mitaka'})
         self.assertEqual(404, res.status_code)
 
-    @mock.patch('kostyor.db.api.get_cluster')
     @mock.patch('kostyor.db.api.create_cluster_upgrade')
-    def test_create_cluster_upgrade(self,
-                                    fake_db_create_cluster_upgrade,
-                                    fake_get_cluster):
+    def test_create_cluster_upgrade(self, fake_db_create_cluster_upgrade):
         expected = {'id': self.cluster_id, 'status': 'upgrading'}
 
         fake_db_create_cluster_upgrade.return_value = expected
-        fake_get_cluster.return_value = {'id': self.cluster_id,
-                                         'name': 'test cluster',
-                                         'version': constants.LIBERTY,
-                                         'status': constants.READY_FOR_UPGRADE}
         res = self.app.post('/upgrade-cluster/{}'.format(self.cluster_id),
                             data={'version': 'newton'})
         data = res.data.decode('utf-8')

--- a/kostyor/tests/unit/test_db_api.py
+++ b/kostyor/tests/unit/test_db_api.py
@@ -1,3 +1,6 @@
+import uuid
+import datetime
+
 from kostyor.db import models
 from kostyor.db import api as db_api
 
@@ -6,7 +9,7 @@ from sqlalchemy.orm import sessionmaker
 
 from oslotest import base
 
-from kostyor.common import constants
+from kostyor.common import constants, exceptions
 
 
 class KostyorTestContext(object):
@@ -103,3 +106,84 @@ class DbApiTestCase(base.BaseTestCase):
     def test_get_services_by_host_wrong_host_id_empty_list(self):
         result = db_api.get_services_by_host('fake-host-id')
         self.assertEqual([], result)
+
+    def test_get_upgrades(self):
+        expected = [
+            {
+                'id': str(uuid.uuid4()),
+                'cluster_id': str(uuid.uuid4()),
+                'from_version': constants.MITAKA,
+                'to_version': constants.NEWTON,
+                'status': constants.UPGRADE_PAUSED,
+                'upgrade_start_time': datetime.datetime.utcnow(),
+                'upgrade_end_time': datetime.datetime.utcnow(),
+            } for _ in range(0, 2)
+        ]
+        self.context.session.bulk_insert_mappings(models.UpgradeTask, expected)
+
+        retrieved = db_api.get_upgrades()
+        self.assertEqual(expected, retrieved)
+
+    def test_get_upgrades_w_cluster_id(self):
+        expected = [
+            {
+                'id': str(uuid.uuid4()),
+                'cluster_id': str(uuid.uuid4()),
+                'from_version': constants.MITAKA,
+                'to_version': constants.NEWTON,
+                'status': constants.UPGRADE_PAUSED,
+                'upgrade_start_time': datetime.datetime.utcnow(),
+                'upgrade_end_time': datetime.datetime.utcnow(),
+            } for _ in range(0, 3)
+        ]
+        # make second entry to belong the same cluster as first one does
+        expected[1]['cluster_id'] = expected[0]['cluster_id']
+        self.context.session.bulk_insert_mappings(models.UpgradeTask, expected)
+
+        retrieved = db_api.get_upgrades(expected[0]['cluster_id'])
+        self.assertEqual(expected[0:2], retrieved)
+
+    def test_create_cluster_upgrade(self):
+        cluster = db_api.create_cluster("test",
+                                        constants.MITAKA,
+                                        constants.READY_FOR_UPGRADE)
+        upgrade = db_api.create_cluster_upgrade(cluster['id'],
+                                                constants.NEWTON)
+
+        self.assertIsNotNone(upgrade['id'])
+        self.assertEqual(cluster['id'], upgrade['cluster_id'])
+        self.assertEqual(constants.MITAKA, upgrade['from_version'])
+        self.assertEqual(constants.NEWTON, upgrade['to_version'])
+
+    def test_create_cluster_upgrade_not_found(self):
+        self.assertRaises(exceptions.ClusterNotFound,
+                          db_api.create_cluster_upgrade,
+                          'non-existing-id',
+                          constants.NEWTON)
+
+    def test_create_cluster_upgrade_version_unknown(self):
+        cluster = db_api.create_cluster("test",
+                                        constants.UNKNOWN,
+                                        constants.READY_FOR_UPGRADE)
+        self.assertRaises(exceptions.ClusterVersionIsUnknown,
+                          db_api.create_cluster_upgrade,
+                          cluster['id'],
+                          constants.NEWTON)
+
+    def test_create_cluster_upgrade_in_progress(self):
+        cluster = db_api.create_cluster("test",
+                                        constants.MITAKA,
+                                        constants.UPGRADE_IN_PROGRESS)
+        self.assertRaises(exceptions.UpgradeIsInProgress,
+                          db_api.create_cluster_upgrade,
+                          cluster['id'],
+                          constants.NEWTON)
+
+    def test_create_cluster_upgrade_lower_version(self):
+        cluster = db_api.create_cluster("test",
+                                        constants.MITAKA,
+                                        constants.READY_FOR_UPGRADE)
+        self.assertRaises(exceptions.CannotUpgradeToLowerVersion,
+                          db_api.create_cluster_upgrade,
+                          cluster['id'],
+                          constants.LIBERTY)

--- a/kostyor/tests/unit/test_db_api.py
+++ b/kostyor/tests/unit/test_db_api.py
@@ -42,10 +42,9 @@ class DbApiTestCase(base.BaseTestCase):
     def test_create_cluster(self):
         result = db_api.get_clusters()
 
-        self.assertIn("clusters", result)
-        self.assertGreater(len(result['clusters']), 0)
+        self.assertGreater(len(result), 0)
 
-        result_data = result['clusters'][0]
+        result_data = result[0]
 
         self.assertIsNotNone(result_data['id'])
 
@@ -55,7 +54,7 @@ class DbApiTestCase(base.BaseTestCase):
             db_api.create_cluster("test" + str(i), constants.MITAKA,
                                   constants.READY_FOR_UPGRADE)
 
-        expected = db_api.get_clusters()['clusters']
+        expected = db_api.get_clusters()
 
         cluster_names = [cluster['name'] for cluster in expected]
         for i in range(0, 10):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-neutronclient
 pbr
 pytz
 flask
+flask_restful
 six
 oslo.utils
 sqlalchemy


### PR DESCRIPTION
Flask-RESTful is an extension for Flask that adds support for quickly
building REST APIs. It encourages best practices with minimal setup.

This commit introduces flask-restful dependency and implement
`/clusters` resource that lists and show OpenStack environments.