### PR TITLE
Remove deprecated /cluster-list endpoint

### DIFF
--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -301,11 +301,6 @@ def rollback_cluster_upgrade(cluster_id):
     return resp
 
 
-@app.route('/cluster-list', methods=['GET'])
-def cluster_list_deprecated():
-    return redirect(url_for('.cluster_list'))
-
-
 @app.route('/clusters', methods=['GET'])
 def cluster_list():
     clusters = db_api.get_clusters()


### PR DESCRIPTION
Since commit [1] we don't need "/cluster-list" endpoint anymore. From now
on "/clusters" endpoint is used instead.

[1] https://github.com/sc68cal/Kostyor-cli/commit/8fdab037cbce4565e581f26d6d5de42820ba9afa