### PR TITLE
Push exception handling into the DB layer

### DIFF
--- a/kostyor/common/exceptions.py
+++ b/kostyor/common/exceptions.py
@@ -24,3 +24,7 @@ class CannotUpgradeToLowerVersion(BadRequest):
 
 class UpgradeIsInProgress(BadRequest):
     """Upgrade operation is in progress."""
+
+
+class UpgradeNotFound(Exception):
+    """Upgrade not found in database"""

--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -44,7 +44,11 @@ def get_cluster(cluster_id):
 
 def get_upgrade_by_cluster(cluster_id):
     u_task = _get_most_recent_upgrade_task(cluster_id)
-    return u_task.to_dict()
+    if u_task:
+        return u_task.to_dict()
+    else:
+        raise exceptions.UpgradeNotFound("No upgrade found for Cluster ID %s"
+                                         % cluster_id)
 
 
 def get_upgrade(upgrade_id):

--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -11,6 +11,7 @@ from keystoneauth1.identity import v2
 import six
 
 from kostyor.common import constants
+from kostyor.common import exceptions as k_exceptions
 from kostyor import conf
 from kostyor.inventory import discover
 from kostyor import resources
@@ -53,12 +54,12 @@ def generate_response(status, message):
 
 @app.route('/upgrade-status/<cluster_id>')
 def get_upgrade_status(cluster_id):
-    upgrade = db_api.get_upgrade_by_cluster(cluster_id)
-    if upgrade:
+    try:
+        upgrade = db_api.get_upgrade_by_cluster(cluster_id)
         full_url = url_for(
             '.upgrade', cluster_id=cluster_id, upgrade_id=upgrade['id'])
         return redirect(full_url)
-    else:
+    except k_exceptions.UpgradeNotFound:
         return generate_response(404, 'Upgrade for cluster %s not found' %
                                  cluster_id)
 

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -8,6 +8,7 @@ import mock
 
 from kostyor.rest_api import app
 from kostyor.common import constants
+from kostyor.common import exceptions as k_exceptions
 sys.modules['kostyor.conf'] = mock.Mock()
 
 
@@ -41,8 +42,8 @@ class KostyorRestAPITest(unittest.TestCase):
         }
 
     @mock.patch('kostyor.db.api.get_upgrade_by_cluster')
-    def test_get_upgrade_status_404(self, fake_db_get_upgrade_by_cluster):
-        fake_db_get_upgrade_by_cluster.return_value = None
+    def test_get_upgrade_status_404(self, fake_db_get_upgrade):
+        fake_db_get_upgrade.side_effect = k_exceptions.UpgradeNotFound
         res = self.app.get('/upgrade-status/{}'.format(self.cluster_id))
         self.assertEqual(404, res.status_code)
 

--- a/kostyor/tests/unit/test_db_api.py
+++ b/kostyor/tests/unit/test_db_api.py
@@ -108,6 +108,11 @@ class DbApiTestCase(base.BaseTestCase):
         result = db_api.get_services_by_host('fake-host-id')
         self.assertEqual([], result)
 
+    def test_get_upgrade_raises_exception(self):
+        self.assertRaises(exceptions.UpgradeNotFound,
+                          db_api.get_upgrade_by_cluster,
+                          'does-not-exist')
+
     def test_get_upgrades(self):
         expected = [
             {


### PR DESCRIPTION
SQLAlchemy's .first() call can return an item or None,
so push the handling of that case into the DB API layer where it belongs