### PR TITLE
Add REST API endpoints '/services' and '/hosts'

### DIFF
--- a/contrib/openapi.yml
+++ b/contrib/openapi.yml
@@ -41,6 +41,50 @@ paths:
           description: Cluster not found.
           schema:
             $ref: '#/definitions/Error'
+  /clusters/{id}/hosts:
+    get:
+      summary: List hosts in a cluster
+      parameters:
+        - name: id
+          type: string
+          pattern: *UUID_PATTERN
+          required: true
+          in: path
+          description: |
+            Unique identifier representing the specific cluster.
+      responses:
+        200:
+          description: List all hosts in the cluster.
+          schema:
+            type: array
+            tems:
+              $ref: '#/definitions/Host'
+        404:
+          description: Cluster not found.
+          schema:
+            $ref: '#/definitions/Error'
+  /clusters/{id}/services:
+    get:
+      summary: List services in a cluster
+      parameters:
+        - name: id
+          type: string
+          pattern: *UUID_PATTERN
+          required: true
+          in: path
+          description: |
+            Unique identifier representing the specific cluster.
+      responses:
+        200:
+          description: List of all services in a cluster.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Service'
+        404:
+          description: Cluster not found.
+          schema:
+            $ref: '#/definitions/Error'
   /clusters/{id}/upgrades:
     get:
       summary: List Upgrade Tasks of Clusters
@@ -199,3 +243,41 @@ definitions:
         type: string
         description: |
           A unique identifier representing assigned cluster.
+  Host:
+    type: object
+    required:
+      - id
+      - hostname
+      - cluster_id
+    properties:
+      id:
+        type: string
+        pattern: *UUID_PATTERN
+      hostname:
+        type: string
+      cluster_id:
+        type: string
+        pattern: *UUID_PATTERN
+        description: |
+          A unique identifier representing assigned cluster.
+  Service:
+    type: object
+    required:
+      - id
+      - name
+      - host_id
+      - version
+    properties:
+      id:
+        type: string
+        pattern: *UUID_PATTERN
+      name:
+        type: string
+      host_id:
+        type: string
+        pattern: *UUID_PATTERN
+        description: |
+          A unique identifier representing assigned host.
+      version:
+        type: string
+        enum: *OPENSTACK_VERSIONS

--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -120,6 +120,12 @@ def create_host(name, cluster_id):
             'cluster_id': new_host.cluster_id}
 
 
+def get_hosts_by_cluster(cluster_id):
+    hosts = db_session.query(models.Host).filter_by(
+        cluster_id=cluster_id)
+    return [host.to_dict() for host in hosts]
+
+
 def create_service(name, host_id, version):
     new_service = models.Service()
     new_service.name = name
@@ -131,6 +137,12 @@ def create_service(name, host_id, version):
             'name': new_service.name,
             'host_id': new_service.host_id,
             'version': new_service.version}
+
+
+def get_services_by_host(host_id):
+    services = db_session.query(models.Service).filter_by(
+        host_id=host_id)
+    return [service.to_dict() for service in services]
 
 
 def create_cluster(name, version, status):

--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -307,5 +307,33 @@ def cluster_list():
     return jsonify(clusters)
 
 
+@app.route('/clusters/<cluster_id>/services')
+def service_list(cluster_id):
+    try:
+        db_api.get_cluster(cluster_id)
+    except Exception as e:
+        return generate_response(404, six.text_type(e))
+
+    hosts = db_api.get_hosts_by_cluster(cluster_id)
+    services = []
+    for host in hosts:
+        services += db_api.get_services_by_host(host['id'])
+    services = sorted(services, key=lambda s: s['name'])
+    resp = jsonify(services)
+    return resp
+
+
+@app.route('/clusters/<cluster_id>/hosts')
+def host_list(cluster_id):
+    try:
+        db_api.get_cluster(cluster_id)
+    except Exception as ex:
+        return generate_response(404, six.text_type(ex))
+
+    hosts = db_api.get_hosts_by_cluster(cluster_id)
+    resp = jsonify(hosts)
+    return resp
+
+
 if __name__ == '__main__':
     app.run()


### PR DESCRIPTION
Add API endpoints to query out services in a cluster
and hosts that are part of a cluster.

Add DB API methods for getting services and hosts by cluster ID.

Add unit tests.