### PR TITLE
Fix tools/run_integration.sh script

### DIFF
--- a/tools/run_integration.sh
+++ b/tools/run_integration.sh
@@ -10,7 +10,7 @@ export KOSTYOR_PORT=5000
 
 python setup.py install
 
-if ! [ -d /tmp/kostyor-cli ]; then
+if ! [ -d /tmp/Kostyor-cli ]; then
     cd /tmp
     git clone https://github.com/sc68cal/Kostyor-cli.git
 else


### PR DESCRIPTION
run_integration.sh used to produce a failure on case-sensitive filesystems
in case when Kostyor-cli is already cloned to /tmp/Kostyor-cli. This
happened due to misspelled directory name which is "kostyor-cli",
not "Kostyor-cli".