### PR TITLE
Introduce schema validation for requests

### DIFF
--- a/kostyor/resources/clusters.py
+++ b/kostyor/resources/clusters.py
@@ -1,9 +1,14 @@
+import cerberus
+
 from flask import request
 from flask_restful import Resource, fields, marshal_with, abort
 
+from kostyor.common import constants
 from kostyor.db import api as db_api
 
 
+# Output Schema is a Flask-RESTful marshaling schema that's used to
+# expose only limited set of fields and to do type transformation.
 _PUBLIC_ATTRIBUTES = {
     'id': fields.String,
     'name': fields.String,
@@ -22,6 +27,13 @@ class Clusters(Resource):
 
 class Cluster(Resource):
 
+    _schema = {
+        'id': {'type': 'string', 'readonly': True},
+        'name': {'type': 'string'},
+        'status': {'type': 'string', 'allowed': constants.STATUSES},
+        'version': {'type': 'string', 'allowed': constants.OPENSTACK_VERSIONS},
+    }
+
     @marshal_with(_PUBLIC_ATTRIBUTES)
     def get(self, cluster_id):
         cluster = db_api.get_cluster(cluster_id)
@@ -33,4 +45,12 @@ class Cluster(Resource):
 
     @marshal_with(_PUBLIC_ATTRIBUTES)
     def put(self, cluster_id):
+        validator = cerberus.Validator(self._schema)
+        if not validator.validate(request.get_json()):
+            abort(400,
+                  message='Cannot update a cluster "%s", passed data are '
+                          'incorrect. See "errors" attribute for details.'
+                          % cluster_id,
+                  errors=validator.errors)
+
         return db_api.update_cluster(cluster_id, **request.form)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pbr
 pytz
 flask
 flask_restful
+cerberus
 six
 oslo.utils
 sqlalchemy


### PR DESCRIPTION
It's very convenient to have schema validation for HTTP requests, since
it allows us to have rules defined declaratively and do not hardcoded in
the code.

This commit adds Cerberus schema to validation input JSONs for POST and
PUT requests to /clusters and /clusters/:id/upgrades resources.