### PR TITLE
PUT /upgrades/:id returns 404 if cluster not found

### DIFF
--- a/kostyor/resources/upgrades.py
+++ b/kostyor/resources/upgrades.py
@@ -94,6 +94,10 @@ class Upgrade(Resource):
                   errors=validator.errors)
 
         fn = self._actions[payload['action']]
+        try:
+            # Would it better to pass upgrade_id instead?
+            upgrade = fn(payload['cluster_id'])
+        except exceptions.NotFound as exc:
+            abort(404, message=six.text_type(exc))
 
-        # Would it better to pass upgrade_id instead?
-        return fn(payload['cluster_id'])
+        return upgrade, 200

--- a/kostyor/tests/unit/test_db_api.py
+++ b/kostyor/tests/unit/test_db_api.py
@@ -187,3 +187,23 @@ class DbApiTestCase(base.BaseTestCase):
                           db_api.create_cluster_upgrade,
                           cluster['id'],
                           constants.LIBERTY)
+
+    def test_cancel_cluster_upgrade_cluster_not_found(self):
+        self.assertRaises(exceptions.ClusterNotFound,
+                          db_api.cancel_cluster_upgrade,
+                          'non-existing-id')
+
+    def test_continue_cluster_upgrade_cluster_not_found(self):
+        self.assertRaises(exceptions.ClusterNotFound,
+                          db_api.continue_cluster_upgrade,
+                          'non-existing-id')
+
+    def test_pause_cluster_upgrade_cluster_not_found(self):
+        self.assertRaises(exceptions.ClusterNotFound,
+                          db_api.pause_cluster_upgrade,
+                          'non-existing-id')
+
+    def test_rollback_cluster_upgrade_cluster_not_found(self):
+        self.assertRaises(exceptions.ClusterNotFound,
+                          db_api.rollback_cluster_upgrade,
+                          'non-existing-id')


### PR DESCRIPTION
PUT request on /upgrades/:id has the following mandatory payload:

    {
        "cluster_id": "<cluster-id>",
        "action": "<action-to-perform>"
    }

So far in case cluster not found it fails with 500. We need to handle
this properly and return 404 in this case. This commit introduces this.