### PR TITLE
Move /clusters/:id/hosts to Flask-RESTFul

### DIFF
--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -157,8 +157,10 @@ def create_host(name, cluster_id):
 
 
 def get_hosts_by_cluster(cluster_id):
-    hosts = db_session.query(models.Host).filter_by(
-        cluster_id=cluster_id)
+    # ensure cluster exists and throw ClusterNotFound if not
+    cluster = _get_cluster(cluster_id)
+
+    hosts = db_session.query(models.Host).filter_by(cluster_id=cluster.id)
     return [host.to_dict() for host in hosts]
 
 

--- a/kostyor/resources/__init__.py
+++ b/kostyor/resources/__init__.py
@@ -1,10 +1,12 @@
 from .clusters import Clusters, Cluster
+from .hosts import Hosts
 from .upgrades import Upgrades, Upgrade
 
 
 __all__ = [
     'Clusters',
     'Cluster',
+    'Hosts',
     'Upgrades',
     'Upgrade',
 ]

--- a/kostyor/resources/hosts.py
+++ b/kostyor/resources/hosts.py
@@ -1,0 +1,27 @@
+import six
+
+from flask_restful import Resource, fields, marshal_with, abort
+
+from kostyor.common import exceptions
+from kostyor.db import api as db_api
+
+
+# Output Schema is a Flask-RESTful marshaling schema that's used to
+# expose only limited set of fields and to do type transformation.
+_PUBLIC_ATTRIBUTES = {
+    'id': fields.String,
+    'hostname': fields.String,
+    'cluster_id': fields.String,
+}
+
+
+class Hosts(Resource):
+
+    @marshal_with(_PUBLIC_ATTRIBUTES)
+    def get(self, cluster_id):
+        try:
+            hosts = db_api.get_hosts_by_cluster(cluster_id)
+        except exceptions.NotFound as exc:
+            abort(404, message=six.text_type(exc))
+
+        return hosts

--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -32,6 +32,7 @@ app.config['ERROR_404_HELP'] = False
 # some factory function to return Flask application.
 api.add_resource(resources.Clusters, '/clusters')
 api.add_resource(resources.Cluster, '/clusters/<cluster_id>')
+api.add_resource(resources.Hosts, '/clusters/<cluster_id>/hosts')
 
 api.add_resource(resources.Upgrades, '/upgrades')
 api.add_resource(resources.Upgrade, '/upgrades/<upgrade_id>')
@@ -166,18 +167,6 @@ def service_list(cluster_id):
         services += db_api.get_services_by_host(host['id'])
     services = sorted(services, key=lambda s: s['name'])
     resp = jsonify(services)
-    return resp
-
-
-@app.route('/clusters/<cluster_id>/hosts')
-def host_list(cluster_id):
-    try:
-        db_api.get_cluster(cluster_id)
-    except Exception as ex:
-        return generate_response(404, six.text_type(ex))
-
-    hosts = db_api.get_hosts_by_cluster(cluster_id)
-    resp = jsonify(hosts)
     return resp
 
 

--- a/kostyor/tests/unit/resources/test_hosts.py
+++ b/kostyor/tests/unit/resources/test_hosts.py
@@ -1,0 +1,51 @@
+import json
+
+import mock
+import oslotest.base
+
+from kostyor.common import exceptions
+from kostyor.rest_api import app
+
+
+class TestHostsEndpoint(oslotest.base.BaseTestCase):
+
+    def setUp(self):
+        super(TestHostsEndpoint, self).setUp()
+        self.app = app.test_client()
+        self.fake_host = {
+            'id': '1111',
+            'hostname': 'hostname_1',
+            'cluster_id': '1234'
+        }
+
+    @mock.patch('kostyor.db.api.get_hosts_by_cluster')
+    def test_host_list_cluster_exists_success(self, get_hosts_by_cluster):
+        fake_host_2 = {
+            'id': '2222',
+            'hostname': 'hostname_2',
+            'cluster_id': '1234'
+        }
+        fake_hosts = [self.fake_host, fake_host_2]
+        get_hosts_by_cluster.return_value = fake_hosts
+
+        resp = self.app.get('/clusters/1234/hosts')
+        self.assertEqual(200, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        self.assertEqual(fake_hosts, received)
+
+        get_hosts_by_cluster.assert_called_once_with('1234')
+
+    @mock.patch('kostyor.db.api.get_hosts_by_cluster')
+    def test_host_list_wrong_cluster_id_404(self, get_hosts_by_cluster):
+        get_hosts_by_cluster.side_effect = \
+            exceptions.ClusterNotFound('cluster not found')
+
+        resp = self.app.get('/clusters/fake/hosts')
+        self.assertEqual(404, resp.status_code)
+
+        received = json.loads(resp.get_data(as_text=True))
+        error = {'message': 'cluster not found'}
+        self.assertEqual(error, received)
+
+        get_hosts_by_cluster.assert_called_once_with('fake')

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -165,36 +165,6 @@ class KostyorRestAPITest(unittest.TestCase):
 
     @mock.patch.object(db_api, 'get_cluster', mock.Mock())
     @mock.patch.object(db_api, 'get_hosts_by_cluster', mock.Mock())
-    def test_host_list_cluster_exists_success(self):
-        fake_host_2 = {
-            'id': '2222',
-            'name': 'hostname_2',
-            'cluster_id': '1234'
-        }
-        fake_hosts = [self.fake_host, fake_host_2]
-        db_api.get_hosts_by_cluster.return_value = fake_hosts
-
-        res = self.app.get('/clusters/1234/hosts')
-
-        self.assertEqual(200, res.status_code)
-        hosts = res.get_json()
-        self.assertEqual(fake_hosts, hosts)
-        db_api.get_cluster.assert_called_once_with('1234')
-        db_api.get_hosts_by_cluster.assert_called_once_with('1234')
-
-    @mock.patch.object(db_api, 'get_cluster', mock.Mock())
-    @mock.patch.object(db_api, 'get_hosts_by_cluster', mock.Mock())
-    def test_host_list_wrong_cluster_id_404(self):
-        db_api.get_cluster.side_effect = Exception("Wrong cluster ID.")
-
-        res = self.app.get('/clusters/fake/hosts')
-
-        self.assertEqual(404, res.status_code)
-        db_api.get_cluster.assert_called_once_with('fake')
-        self.assertFalse(db_api.get_hosts_by_cluster.called)
-
-    @mock.patch.object(db_api, 'get_cluster', mock.Mock())
-    @mock.patch.object(db_api, 'get_hosts_by_cluster', mock.Mock())
     @mock.patch.object(db_api, 'get_services_by_host', mock.Mock())
     def test_service_list_cluster_exists_success(self):
         fake_hosts = [self.fake_host, ]

--- a/kostyor/tests/unit/test_db_api.py
+++ b/kostyor/tests/unit/test_db_api.py
@@ -86,9 +86,10 @@ class DbApiTestCase(base.BaseTestCase):
         result = db_api.get_hosts_by_cluster(self.cluster['id'])
         self.assertEqual(expected_result, result)
 
-    def test_get_host_by_cluster_wrong_cluster_id_empty_list(self):
-        result = db_api.get_hosts_by_cluster('fake-cluster-id')
-        self.assertEqual([], result)
+    def test_get_host_by_cluster_wrong_cluster(self):
+        self.assertRaises(exceptions.ClusterNotFound,
+                          db_api.get_hosts_by_cluster,
+                          'non-existing-id')
 
     def test_get_services_by_host_existing_cluster_success(self):
         host = db_api.create_host('hostname', self.cluster['id'])


### PR DESCRIPTION
This is a part of internal refactoring by moving Flask endpoints to
Flask-RESTful format. This time we have moved endpoint that lists
cluster hosts.