### PR TITLE
Remove '/create-discovery-method' endpoint

### DIFF
--- a/kostyor/db/api.py
+++ b/kostyor/db/api.py
@@ -60,10 +60,6 @@ def get_upgrade_versions(cluster_id):
     return {'versions': constants.OPENSTACK_VERSIONS}
 
 
-def create_discovery_method(method):
-    return {'id': '1', 'method': method}
-
-
 def create_cluster_upgrade(cluster_id, to_version):
     cluster = _get_cluster(cluster_id)
 

--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -91,22 +91,6 @@ def list_upgrade_versions():
     return jsonify(res)
 
 
-@app.route('/create-discovery-method', methods=['POST'])
-def create_discovery_method():
-    discovery_method = request.form.get('method')
-    disc_method = db_api.create_discovery_method(discovery_method)
-    if not disc_method:
-        resp = generate_response(
-            404,
-            'Failed to create discovery method: %s' % discovery_method
-        )
-        return resp
-
-    resp = jsonify(disc_method)
-    resp.status_code = 201
-    return resp
-
-
 @app.route('/discover-cluster', methods=['POST'])
 def discover_cluster():
     discovery_method = str(request.form.get('method')).lower()

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -68,22 +68,6 @@ class KostyorRestAPITest(unittest.TestCase):
         received = res.get_json()
         self.assertEqual(['mitaka', 'newton'], received)
 
-    @mock.patch('kostyor.db.api.create_discovery_method')
-    def test_create_disc_method_404(self, fake_db_create_disc_method):
-        fake_db_create_disc_method.return_value = None
-        res = self.app.post('/create-discovery-method')
-        self.assertEqual(404, res.status_code)
-
-    @mock.patch('kostyor.db.api.create_discovery_method')
-    def test_create_disc_method(self, fake_db_create_disc_method):
-        expected = {'id': '1', 'method': 'method'}
-
-        fake_db_create_disc_method.return_value = expected
-        res = self.app.post('/create-discovery-method')
-        self.assertEqual(201, res.status_code)
-        received = res.get_json()
-        self.assertEqual(expected, received)
-
     @mock.patch('keystoneauth1.identity.v2.Password')
     @mock.patch('keystoneauth1.session.Session')
     @mock.patch(


### PR DESCRIPTION
Remove '/create-discovery-method' REST API endpoint, remove corresponding
unit tests.

Remove DB API stub for method 'create_discovery_method' since it was called
only inside deleted REST API method.