### PR TITLE
Fix tox warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands =
 basepython = python2.7
 deps =
   {[testenv]deps}
+whitelist_externals = bash
 commands = 
   bash tools/run_integration.sh
 


### PR DESCRIPTION
Tox shows warning "test command found but not installed in testenv"
during integration tests running. Add 'bash' to whitelist_externals
in tox.ini file to get rid of this message.