### PR TITLE
[WIP] Add RPC layer with execute(...) celery task

### DIFF
--- a/kostyor/conf.py
+++ b/kostyor/conf.py
@@ -10,5 +10,30 @@ CONF.register_group(database_group)
 CONF.register_opt(connection_opt, group=database_group)
 
 
+rpc_group = cfg.OptGroup(name='rpc', title='RPC settings')
+rpc_opts = [
+    cfg.StrOpt('broker_url',
+               default='sqla+sqlite:////tmp/celery.db',
+               help=('Broker backend to be used. Must be an URL in the form '
+                     'of "transport://user:pass@host:port/vhost".')),
+    cfg.StrOpt('celery_result_backend',
+               default='db+sqlite:////tmp/celery.db',
+               help=('The backend to be used to store task results.')),
+    cfg.StrOpt('celery_task_serializer',
+               default='json',
+               help=('A default serialization method to be used.')),
+    cfg.StrOpt('celery_result_serializer',
+               default='json',
+               help=('Result serialization format to be used.')),
+    cfg.ListOpt('celery_accept_content',
+                default=['json'],
+                help=('A whitelist of serializers to be allowed. If a message '
+                      'is received that is not in this list then the message '
+                      'will be discarded with an error.')),
+]
+CONF.register_group(rpc_group)
+CONF.register_opts(rpc_opts, group=rpc_group)
+
+
 def parse_args(args=[]):
     CONF(args)

--- a/kostyor/rpc/app.py
+++ b/kostyor/rpc/app.py
@@ -1,0 +1,16 @@
+from celery import Celery
+
+from kostyor.conf import CONF
+
+
+def create_app(conf):
+    app = Celery()
+    app.autodiscover_tasks(['kostyor.rpc'])
+
+    for option, value in conf.rpc.items():
+        # celery options are upper-cased, just like in flask
+        app.conf[option.upper()] = value
+
+    return app
+
+app = create_app(CONF)

--- a/kostyor/rpc/tasks/__init__.py
+++ b/kostyor/rpc/tasks/__init__.py
@@ -1,0 +1,6 @@
+from kostyor.rpc.tasks.execute import execute
+
+
+__all__ = [
+    'execute',
+]

--- a/kostyor/rpc/tasks/execute.py
+++ b/kostyor/rpc/tasks/execute.py
@@ -1,0 +1,39 @@
+import time
+import subprocess
+
+from celery.contrib.abortable import AbortableTask
+
+from kostyor.rpc.app import app
+
+
+@app.task(bind=True, base=AbortableTask)
+def execute(self, args, ignore_errors=False):
+    """Execute an arbitrary process and terminate it if abort() is sent.
+
+    In case when process ended with return code non-equal to zero, the
+    exception is raised in order to mark celery task as failed.
+
+    :param args: process with arguments to be executed
+    :param ignore_errors: do not raise exception for '!=0' return codes if True
+    :return: process' return code, or 'None' if it was aborted
+    """
+    process = subprocess.Popen(args)
+
+    # Unfortunately, 'timeout' parameter of 'wait' method has been added in
+    # Python 3.3, so we can't use to do a periodic check for 'is_aborted()'
+    # value and that's why 'poll()' and 'sleep()' are used.
+    while process.poll() is None:
+        if self.is_aborted():
+            process.terminate()
+            break
+
+        time.sleep(1)
+
+    # Celery treats exceptions from task as way to mark it failed. So let's
+    # throw one to do so in case return code is not zero.
+    if all([not ignore_errors,
+            process.returncode is not None,
+            process.returncode != 0]):
+        raise subprocess.CalledProcessError(process.returncode, ' '.join(args))
+
+    return process.returncode

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ oslo.config
 oslo.utils
 sqlalchemy
 alembic
+celery


### PR DESCRIPTION
In order to control OpenStack upgrade flow, we need a way to execute
some external scripts. For instance, in case of OpenStack Ansible we
need to execute a sequence of external scripts.

This commit adds a basic RPC layer with 'execute' task that allows to
run external task and abort it if needed.