### PR TITLE
Remove /upgrade-status/ endpoint since it's unused

### DIFF
--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -3,14 +3,13 @@ import sys
 
 from collections import defaultdict
 
-from flask import Flask, jsonify, redirect, request, url_for
+from flask import Flask, jsonify, request
 from flask_restful import Api
 import six
 from stevedore import driver
 from stevedore import extension
 
 from kostyor.common import constants
-from kostyor.common import exceptions as k_exceptions
 from kostyor import conf
 from kostyor import resources
 
@@ -54,18 +53,6 @@ def discovery_drivers():
     ext_manager = extension.ExtensionManager(
         namespace='kostyor.discovery_drivers')
     return ext_manager.names()
-
-
-@app.route('/upgrade-status/<cluster_id>')
-def get_upgrade_status(cluster_id):
-    try:
-        upgrade = db_api.get_upgrade_by_cluster(cluster_id)
-        full_url = url_for(
-            '.upgrade', cluster_id=cluster_id, upgrade_id=upgrade['id'])
-        return redirect(full_url)
-    except k_exceptions.UpgradeNotFound:
-        return generate_response(404, 'Upgrade for cluster %s not found' %
-                                 cluster_id)
 
 
 @app.route('/discovery-methods')

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -9,7 +9,6 @@ import mock
 from kostyor.inventory import discover
 from kostyor.rest_api import app
 from kostyor.common import constants
-from kostyor.common import exceptions as k_exceptions
 sys.modules['kostyor.conf'] = mock.Mock()
 
 
@@ -47,12 +46,6 @@ class KostyorRestAPITest(unittest.TestCase):
             'tenant_name': 'admin',
             'auth_url': 'http://9.9.9.9'
         }
-
-    @mock.patch('kostyor.db.api.get_upgrade_by_cluster')
-    def test_get_upgrade_status_404(self, fake_db_get_upgrade):
-        fake_db_get_upgrade.side_effect = k_exceptions.UpgradeNotFound
-        res = self.app.get('/upgrade-status/{}'.format(self.cluster_id))
-        self.assertEqual(404, res.status_code)
 
     @mock.patch('kostyor.rest_api.discovery_drivers')
     def test_get_discovery_methods(


### PR DESCRIPTION
The '/upgrade-status' endpoint seems to be nowhere used. It order to
maintain simplicity, let's remove this endpoint and use '/upgrades'
resources instead to retrieve any information about upgrades.
