### PR TITLE
Decision engine: Call driver pre-upgrade hooks

### DIFF
--- a/kostyor/upgrades/driver.py
+++ b/kostyor/upgrades/driver.py
@@ -103,7 +103,7 @@ class UpgradeDriver():
         pass
 
 
-class FakeUpgradeDriver(UpgradeDriver):
+class NoOpDriver(UpgradeDriver):
 
     def stop_upgrade(self, upgrade_task):
         pass

--- a/kostyor/upgrades/strategy.py
+++ b/kostyor/upgrades/strategy.py
@@ -1,0 +1,24 @@
+import abc
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class DefaultStrategy():
+    pass
+
+
+@six.add_metaclass(abc.ABCMeta)
+class HostEvacuateLiveMixin():
+    """
+
+    A strategy that includes using the nova host-evacuate-live API call
+    to live-migrate running instances off a compute node
+
+    http://www.danplanet.com/blog/2016/03/03/evacuate-in-nova-one-command-to-confuse-us-all/
+    """
+
+    def __init__(self):
+        self.host_evacuate_live = True
+
+    def host_evacuate_live(self):
+        return self.host_evacuate_live


### PR DESCRIPTION
These hooks allow an upgrade driver to do any prep work before a service
or host is upgraded.