### PR TITLE
Return noop tasks instead of None in fake driver

### DIFF
--- a/kostyor/rpc/tasks/__init__.py
+++ b/kostyor/rpc/tasks/__init__.py
@@ -1,6 +1,8 @@
 from kostyor.rpc.tasks.execute import execute
+from kostyor.rpc.tasks.noop import noop
 
 
 __all__ = [
     'execute',
+    'noop',
 ]

--- a/kostyor/rpc/tasks/noop.py
+++ b/kostyor/rpc/tasks/noop.py
@@ -1,0 +1,6 @@
+from kostyor.rpc.app import app
+
+
+@app.task
+def noop():
+    pass

--- a/kostyor/tests/unit/upgrades/test_engine.py
+++ b/kostyor/tests/unit/upgrades/test_engine.py
@@ -4,7 +4,19 @@ import mock
 import oslotest.base
 
 from kostyor.common import constants
-from kostyor.upgrades import Engine
+from kostyor.rpc import tasks
+from kostyor.upgrades import Engine, UpgradeDriver
+
+
+class MockUpgradeDriver(UpgradeDriver):
+
+    supports_upgrade_rollback = mock.Mock(return_value=False)
+    stop_upgrade = mock.Mock(return_value=tasks.noop.si())
+    start_upgrade = mock.Mock(return_value=tasks.noop.si())
+    pause_upgrade = mock.Mock(return_value=tasks.noop.si())
+    cancel_upgrade = mock.Mock(return_value=tasks.noop.si())
+    rollback_upgrade = mock.Mock(return_value=tasks.noop.si())
+    continue_upgrade = mock.Mock(return_value=tasks.noop.si())
 
 
 class TestEngine(oslotest.base.BaseTestCase):
@@ -135,7 +147,7 @@ class TestEngine(oslotest.base.BaseTestCase):
         def get_services_by_host(host):
             return services[host]
         self.dbapi.get_services_by_host = get_services_by_host
-        self.engine.driver = mock.Mock()
+        self.engine.driver = MockUpgradeDriver()
 
         self.engine.start()
 

--- a/kostyor/upgrades/__init__.py
+++ b/kostyor/upgrades/__init__.py
@@ -1,6 +1,9 @@
 from kostyor.upgrades.engine import Engine
+from kostyor.upgrades.driver import UpgradeDriver, FakeUpgradeDriver
 
 
 __all__ = [
     'Engine',
+    'UpgradeDriver',
+    'FakeUpgradeDriver',
 ]

--- a/kostyor/upgrades/driver.py
+++ b/kostyor/upgrades/driver.py
@@ -1,6 +1,8 @@
 import abc
 import six
 
+from kostyor.rpc import tasks
+
 
 @six.add_metaclass(abc.ABCMeta)
 class UpgradeDriver():
@@ -22,7 +24,7 @@ class UpgradeDriver():
         host: a kostyor.db.models.Host instance, representing the host that is
         scheduled to be upgraded
         """
-        pass
+        return tasks.noop.si()
 
     def pre_service_upgrade_hook(self, service):
         """Called by the decision engine before a service is upgraded,
@@ -34,7 +36,7 @@ class UpgradeDriver():
         service: a kostyor.db.models.Service instance, representing the service
         that is scheduled to be upgraded
         """
-        pass
+        return tasks.noop.si()
 
     def post_host_upgrade_hook(self, host):
         """Called by the decision engine after a host is upgraded,
@@ -46,7 +48,7 @@ class UpgradeDriver():
         host: a kostyor.db.models.Host instance, representing the host that is
         scheduled to be upgraded
         """
-        pass
+        return tasks.noop.si()
 
     def post_service_upgrade_hook(self, service):
         """Called by the decision engine after a service is upgraded,
@@ -58,7 +60,7 @@ class UpgradeDriver():
         service: a kostyor.db.models.Service instance, representing the service
         that is scheduled to be upgraded
         """
-        pass
+        return tasks.noop.si()
 
     @abc.abstractmethod
     def cancel_upgrade(self, upgrade_task):
@@ -106,22 +108,22 @@ class UpgradeDriver():
 class FakeUpgradeDriver(UpgradeDriver):
 
     def stop_upgrade(self, upgrade_task):
-        pass
+        return tasks.noop.si()
 
     def start_upgrade(self, upgrade_task):
-        pass
+        return tasks.noop.si()
 
     def pause_upgrade(self, upgrade_task):
-        pass
+        return tasks.noop.si()
 
     def cancel_upgrade(self, upgrade_task):
-        pass
+        return tasks.noop.si()
 
     def rollback_upgrade(self, upgrade_task):
-        pass
+        return tasks.noop.si()
 
     def continue_upgrade(self, upgrade_task):
-        pass
+        return tasks.noop.si()
 
     def supports_upgrade_rollback(self):
         return False


### PR DESCRIPTION
According to upgrade engine implementation each driver's method has to
return a Celery task. So let's introduce a 'noop' task and return it
instead of None in fake upgrade driver. That would help to do functional
testing later and allow us to do not patch some things in tests.