### PR TITLE
Align UpgradeDriver interface with UpgradeEngine

### DIFF
--- a/kostyor/tests/unit/upgrades/test_engine.py
+++ b/kostyor/tests/unit/upgrades/test_engine.py
@@ -17,6 +17,10 @@ class MockUpgradeDriver(UpgradeDriver):
     cancel_upgrade = mock.Mock(return_value=tasks.noop.si())
     rollback_upgrade = mock.Mock(return_value=tasks.noop.si())
     continue_upgrade = mock.Mock(return_value=tasks.noop.si())
+    pre_host_upgrade_hook = mock.Mock(return_value=tasks.noop.si())
+    post_host_upgrade_hook = mock.Mock(return_value=tasks.noop.si())
+    pre_service_upgrade_hook = mock.Mock(return_value=tasks.noop.si())
+    post_service_upgrade_hook = mock.Mock(return_value=tasks.noop.si())
 
 
 class TestEngine(oslotest.base.BaseTestCase):
@@ -151,82 +155,135 @@ class TestEngine(oslotest.base.BaseTestCase):
 
         self.engine.start()
 
-        self.assertEqual(24, self.engine.driver.start_upgrade.call_count)
-        self.engine.driver.start_upgrade.assert_has_calls([
+        expected_service_calls = [
             # controller
-            mock.call({'name': 'keystone-wsgi-admin',
+            mock.call(self.upgrade,
+                      {'name': 'keystone-wsgi-admin',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'keystone-wsgi-public',
+            mock.call(self.upgrade,
+                      {'name': 'keystone-wsgi-public',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'glance-api',
+            mock.call(self.upgrade,
+                      {'name': 'glance-api',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'glance-registry',
+            mock.call(self.upgrade,
+                      {'name': 'glance-registry',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'nova-conductor',
+            mock.call(self.upgrade,
+                      {'name': 'nova-conductor',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'nova-scheduler',
+            mock.call(self.upgrade,
+                      {'name': 'nova-scheduler',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'nova-spicehtml5proxy',
+            mock.call(self.upgrade,
+                      {'name': 'nova-spicehtml5proxy',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'nova-api',
+            mock.call(self.upgrade,
+                      {'name': 'nova-api',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-server',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-server',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-linuxbridge-agent',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-linuxbridge-agent',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-l3-agent',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-l3-agent',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-dhcp-agent',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-dhcp-agent',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-metering-agent',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-metering-agent',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-metadata-agent',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-metadata-agent',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-ns-metadata-proxy',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-ns-metadata-proxy',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'cinder-api',
+            mock.call(self.upgrade,
+                      {'name': 'cinder-api',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'cinder-scheduler',
+            mock.call(self.upgrade,
+                      {'name': 'cinder-scheduler',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'heat-api',
+            mock.call(self.upgrade,
+                      {'name': 'heat-api',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'heat-engine',
+            mock.call(self.upgrade,
+                      {'name': 'heat-engine',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'heat-api-cfn',
+            mock.call(self.upgrade,
+                      {'name': 'heat-api-cfn',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'heat-api-cloudwatch',
+            mock.call(self.upgrade,
+                      {'name': 'heat-api-cloudwatch',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000002',
                        'version': constants.MITAKA}),
             # compute
-            mock.call({'name': 'nova-compute',
+            mock.call(self.upgrade,
+                      {'name': 'nova-compute',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000001',
                        'version': constants.MITAKA}),
-            mock.call({'name': 'neutron-linuxbridge-agent',
+            mock.call(self.upgrade,
+                      {'name': 'neutron-linuxbridge-agent',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000001',
                        'version': constants.MITAKA}),
 
             # storage
-            mock.call({'name': 'cinder-volume',
+            mock.call(self.upgrade,
+                      {'name': 'cinder-volume',
                        'host_id': '5708c51f-5421-4ecd-9a9e-000000000003',
                        'version': constants.MITAKA}),
-        ])
+        ]
+        self.assertEqual(
+            expected_service_calls,
+            self.engine.driver.pre_service_upgrade_hook.call_args_list)
+        self.assertEqual(
+            expected_service_calls,
+            self.engine.driver.start_upgrade.call_args_list)
+        self.assertEqual(
+            expected_service_calls,
+            self.engine.driver.post_service_upgrade_hook.call_args_list)
+
+        expected_host_calls = [
+            mock.call(self.upgrade,
+                      {'hostname': 'host-2',
+                       'cluster_id': '2ba8fad8-3a0f-47db-a45b-62df1d811687',
+                       'id': '5708c51f-5421-4ecd-9a9e-000000000002'}),
+            mock.call(self.upgrade,
+                      {'hostname': 'host-1',
+                       'cluster_id': '2ba8fad8-3a0f-47db-a45b-62df1d811687',
+                       'id': '5708c51f-5421-4ecd-9a9e-000000000001'}),
+            mock.call(self.upgrade,
+                      {'hostname': 'host-3',
+                       'cluster_id': '2ba8fad8-3a0f-47db-a45b-62df1d811687',
+                       'id': '5708c51f-5421-4ecd-9a9e-000000000003'}),
+        ]
+        self.assertEqual(
+            expected_host_calls,
+            self.engine.driver.pre_host_upgrade_hook.call_args_list)
+        self.assertEqual(
+            expected_host_calls,
+            self.engine.driver.post_host_upgrade_hook.call_args_list)

--- a/kostyor/upgrades/__init__.py
+++ b/kostyor/upgrades/__init__.py
@@ -1,9 +1,9 @@
 from kostyor.upgrades.engine import Engine
-from kostyor.upgrades.driver import UpgradeDriver, FakeUpgradeDriver
+from kostyor.upgrades.driver import UpgradeDriver, NoOpDriver
 
 
 __all__ = [
     'Engine',
     'UpgradeDriver',
-    'FakeUpgradeDriver',
+    'NoOpDriver',
 ]

--- a/kostyor/upgrades/driver.py
+++ b/kostyor/upgrades/driver.py
@@ -14,115 +14,138 @@ class UpgradeDriver():
         """
         pass
 
-    def pre_host_upgrade_hook(self, host):
+    def pre_host_upgrade_hook(self, upgrade_task, host):
         """Called by the decision engine before a host is upgraded,
         allows an UpgradeDriver the opportunity to do any operations required
         before the host is upgraded
 
-        Params
+        :param host: a host that is scheduled to be upgraded
+        :type host: a kostyor.db.models.Host instance as a dict
 
-        host: a kostyor.db.models.Host instance, representing the host that is
-        scheduled to be upgraded
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
         """
         return tasks.noop.si()
 
-    def pre_service_upgrade_hook(self, service):
+    def pre_service_upgrade_hook(self, upgrade_task, service):
         """Called by the decision engine before a service is upgraded,
         allows an UpgradeDriver the opportunity to do any operations required
         before a service is upgraded
 
-        Params
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
 
-        service: a kostyor.db.models.Service instance, representing the service
-        that is scheduled to be upgraded
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
         """
         return tasks.noop.si()
 
-    def post_host_upgrade_hook(self, host):
+    def post_host_upgrade_hook(self, upgrade_task, host):
         """Called by the decision engine after a host is upgraded,
         allows an UpgradeDriver the opportunity to do any operations required
         after the host is upgraded
 
-        Params
+        :param host: a host that is scheduled to be upgraded
+        :type host: a kostyor.db.models.Service instance as a dict
 
-        host: a kostyor.db.models.Host instance, representing the host that is
-        scheduled to be upgraded
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
         """
         return tasks.noop.si()
 
-    def post_service_upgrade_hook(self, service):
+    def post_service_upgrade_hook(self, upgrade_task, service):
         """Called by the decision engine after a service is upgraded,
         allows an UpgradeDriver the opportunity to do any operations required
         after a service is upgraded
 
-        Params
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
 
-        service: a kostyor.db.models.Service instance, representing the service
-        that is scheduled to be upgraded
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
         """
         return tasks.noop.si()
 
     @abc.abstractmethod
-    def cancel_upgrade(self, upgrade_task):
+    def cancel_upgrade(self, upgrade_task, service):
         """Called by the decision engine to cancel an upgrade that is in
-        progress"""
+        progress
+
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
+
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        """
         pass
 
     @abc.abstractmethod
-    def rollback_upgrade(self, upgrade_task):
+    def rollback_upgrade(self, upgrade_task, service):
         """Called by the decision engine to rollback a running upgrade
 
-        Params
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
 
-        upgrade_task: A kostyor.db.models.UpgradeTask instance"""
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        """
         pass
 
     @abc.abstractmethod
-    def start_upgrade(self, upgrade_task):
+    def start_upgrade(self, upgrade_task, service):
         """Called by the decision engine to start an upgrade
 
-        Params
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
 
-        upgrade_task: A kostyor.db.models.UpgradeTask instance"""
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        """
         pass
 
     @abc.abstractmethod
-    def stop_upgrade(self, upgrade_task):
+    def stop_upgrade(self, upgrade_task, service):
         """Called by the decision engine to stop a running upgrade
 
-        Params
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
 
-        upgrade_task: A kostyor.db.models.UpgradeTask instance"""
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        """
         pass
 
     @abc.abstractmethod
-    def pause_upgrade(self, upgrade_task):
+    def pause_upgrade(self, upgrade_task, service):
         """Called by the decision engine to pause a running upgrade
 
-        Params
+        :param service: a service that is scheduled to be upgraded
+        :type service: a kostyor.db.models.Service instance as a dict
 
-        upgrade_task: A kostyor.db.models.UpgradeTask instance"""
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        """
         pass
 
 
 class NoOpDriver(UpgradeDriver):
 
-    def stop_upgrade(self, upgrade_task):
+    def stop_upgrade(self, upgrade_task, service):
         return tasks.noop.si()
 
-    def start_upgrade(self, upgrade_task):
+    def start_upgrade(self, upgrade_task, service):
         return tasks.noop.si()
 
-    def pause_upgrade(self, upgrade_task):
+    def pause_upgrade(self, upgrade_task, service):
         return tasks.noop.si()
 
-    def cancel_upgrade(self, upgrade_task):
+    def cancel_upgrade(self, upgrade_task, service):
         return tasks.noop.si()
 
-    def rollback_upgrade(self, upgrade_task):
+    def rollback_upgrade(self, upgrade_task, service):
         return tasks.noop.si()
 
-    def continue_upgrade(self, upgrade_task):
+    def continue_upgrade(self, upgrade_task, service):
         return tasks.noop.si()
 
     def supports_upgrade_rollback(self):


### PR DESCRIPTION
The main methods of UpgradeDriver interface receive upgrade task as a
param. However, according to UpgradeEngine implementation they receive
a service instance scheduled to be upgraded (as a dict) instead.

This commit aligns the interface in order to fix engine's needs.