### PR TITLE
Catch discovery driver loading errors

### DIFF
--- a/kostyor/rest_api.py
+++ b/kostyor/rest_api.py
@@ -102,19 +102,18 @@ def discover_cluster():
         for key in request.form:
             if key not in ['method', 'cluster_name']:
                 discovery_args[key] = request.form.get(key, None)
-
-        discovery_driver = driver.DriverManager(
-            namespace='kostyor.discovery_drivers',
-            name=discovery_method,
-            invoke_on_load=True,
-            invoke_kwds=discovery_args,
-        ).driver
         try:
+            discovery_driver = driver.DriverManager(
+                namespace='kostyor.discovery_drivers',
+                name=discovery_method,
+                invoke_on_load=True,
+                invoke_kwds=discovery_args,
+            ).driver
             services = discovery_driver.discover()
         except Exception as e:
             resp = generate_response(
                 getattr(e, 'http_status', 404),
-                e.message
+                six.text_type(e)
             )
             return resp
 

--- a/kostyor/tests/unit/rest_api/test.py
+++ b/kostyor/tests/unit/rest_api/test.py
@@ -153,3 +153,23 @@ class KostyorRestAPITest(unittest.TestCase):
             invoke_on_load=True,
             invoke_kwds=self.driver_init_kwargs)
         driver.discover.assert_called_once_with()
+
+    @mock.patch('stevedore.driver.DriverManager')
+    @mock.patch('kostyor.rest_api.discovery_drivers')
+    def test_discover_cluster_driver_load_failed_error_response(
+            self,
+            fake_discovery_drivers,
+            fake_driver_manager):
+        fake_discovery_drivers.return_value = ['openstack', ]
+        fake_driver_manager.side_effect = Exception("Cannot load driver.")
+
+        res = self.app.post('/discover-cluster',
+                            data=self.discover_cluster_request_data)
+
+        self.assertEqual(404, res.status_code)
+        fake_discovery_drivers.assert_called_once_with()
+        fake_driver_manager.assert_called_once_with(
+            namespace='kostyor.discovery_drivers',
+            name='openstack',
+            invoke_on_load=True,
+            invoke_kwds=self.driver_init_kwargs)


### PR DESCRIPTION
Catch drivers loading errors in 'discover_cluster' REST API method.
Add unit test.
