### PR TITLE
Use Redis as Celery backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 cache: pip
+services:
+- redis-server
 install:
 - pip install tox
 script:

--- a/kostyor/conf.py
+++ b/kostyor/conf.py
@@ -20,7 +20,7 @@ CONF.register_opt(connection_opt, group=database_group)
 rpc_group = cfg.OptGroup(name='rpc', title='RPC settings')
 rpc_opts = [
     cfg.StrOpt('broker_url',
-               default='sqla+sqlite:////tmp/celery.db',
+               default='redis://localhost:6379/0',
                help=('Broker backend to be used. Must be an URL in the form '
                      'of "transport://user:pass@host:port/vhost".')),
     cfg.StrOpt('celery_result_backend',

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ oslo.config
 oslo.utils
 sqlalchemy
 alembic
-celery
+celery[redis]
 stevedore


### PR DESCRIPTION
Since Celery 4.x the SQLA transport has been dropped so we need to move
away from SQLA transport. This commit changes backend transport from
SQLA to Redis.