### PR TITLE
celery worker: load drivers' tasks on start

### DIFF
--- a/kostyor/rpc/app.py
+++ b/kostyor/rpc/app.py
@@ -1,15 +1,25 @@
-from celery import Celery
+import celery
+import pkg_resources
 
 from kostyor.conf import CONF
 
 
 def create_app(conf):
-    app = Celery()
-    app.autodiscover_tasks(['kostyor.rpc'])
+    app = celery.Celery()
 
     for option, value in conf.rpc.items():
         # celery options are upper-cased, just like in flask
         app.conf[option.upper()] = value
+
+    # Each driver may use own set of Celery tasks, so in order to run them
+    # the Celery worker has to load them into memory. That's why we need to
+    # iterate over Kostyor drivers and lazily load them into memory. The
+    # important note here is that we can't use stevedore because it tries
+    # to load found module immediately which leads to cyclic import error
+    # (drivers import a celery app in order to define own tasks).
+    for ep in pkg_resources.iter_entry_points('kostyor.upgrades.drivers'):
+        package, module = ep.module_name.rsplit('.', 1)
+        app.autodiscover_tasks([package], module)
 
     return app
 

--- a/kostyor/tests/unit/rpc/test_app.py
+++ b/kostyor/tests/unit/rpc/test_app.py
@@ -1,0 +1,22 @@
+import oslotest.base
+
+from kostyor.rpc.app import app
+
+
+# In order to avoid circular import dependencies, we use lazy task
+# loading (see 'app.autodiscover_tasks' method). The real loading
+# is triggered on a special signal that's emitted by worker. Since
+# we don't have worker in unit tests, let's emit this signal
+# manually.
+app.loader.import_default_modules()
+
+
+class TestRpcApp(oslotest.base.BaseTestCase):
+
+    def test_default_tasks_are_loaded(self):
+        expected_tasks = [
+            'kostyor.rpc.tasks.noop.noop',
+            'kostyor.rpc.tasks.execute.execute',
+        ]
+
+        self.assertTrue(set(expected_tasks).issubset(app.tasks))


### PR DESCRIPTION
Each Kostyor driver may provide own set of Celery tasks that needs to be
executed. The thing is, we know nothing about those tasks so a celery
worker will simply fail with message "task not found". In order to fix
that we need to load them into worker's memory on start time.

This commit adds drivers loading into memory 'app.autodiscover_tasks' in
order to avoid cyclic imports. The important thing here is that we can't
use 'stevedore' in this case due to its try to import found modules
immediately.