### PR TITLE
Add 'pre_upgrade_hook' to upgrade driver interface

### DIFF
--- a/kostyor/tests/unit/upgrades/test_engine.py
+++ b/kostyor/tests/unit/upgrades/test_engine.py
@@ -20,6 +20,7 @@ class MockUpgradeDriver(object):
         'cancel_upgrade',
         'rollback_upgrade',
         'continue_upgrade',
+        'pre_upgrade_hook',
         'pre_host_upgrade_hook',
         'post_host_upgrade_hook',
         'pre_service_upgrade_hook',
@@ -295,6 +296,10 @@ class TestEngine(oslotest.base.BaseTestCase):
             expected_host_calls,
             self.engine.driver.post_host_upgrade_hook.call_args_list)
 
+        self.engine.driver.pre_upgrade_hook.assert_called_once_with(
+            self.upgrade
+        )
+
     def test_all_in_one_assignment(self):
         self.dbapi.get_hosts_by_cluster.return_value = [
             {'id': '5708c51f-5421-4ecd-9a9e-000000000001',
@@ -504,3 +509,7 @@ class TestEngine(oslotest.base.BaseTestCase):
         self.assertEqual(
             expected_host_calls,
             self.engine.driver.post_host_upgrade_hook.call_args_list)
+
+        self.engine.driver.pre_upgrade_hook.assert_called_once_with(
+            self.upgrade
+        )

--- a/kostyor/upgrades/drivers/base.py
+++ b/kostyor/upgrades/drivers/base.py
@@ -14,6 +14,16 @@ class UpgradeDriver():
         """
         pass
 
+    def pre_upgrade_hook(self, upgrade_task):
+        """Called by the decision engine before upgrade procedure is started,
+        allows an UpgradeDriver the opportunity to do any operations required
+        before starting other playbooks.
+
+        :param upgrade_task: the upgrade task that the engine is performing
+        :type upgrade_task: kostyor.db.models.UpgradeTask instance
+        """
+        return tasks.noop.si()
+
     def pre_host_upgrade_hook(self, upgrade_task, host):
         """Called by the decision engine before a host is upgraded,
         allows an UpgradeDriver the opportunity to do any operations required

--- a/kostyor/upgrades/engine.py
+++ b/kostyor/upgrades/engine.py
@@ -134,7 +134,7 @@ class Engine(object):
         self.driver = driver
 
     def start(self):
-        subtasks = []
+        subtasks = [self.driver.pre_upgrade_hook(self._upgrade)]
         hosts = dbapi.get_hosts_by_cluster(self._upgrade['cluster_id'])
 
         # We may have plenty controllers each with various set of services.


### PR DESCRIPTION
It's not always possible to do OpenStack upgrades on node-by-node
service-by-service basis. Sometimes we need to do some preparation
steps before running upgrade. For instance, in case of OpenStack
Ansible we need to migrate user configurations to newer version,
update repo containers and so on.

So the idea of 'pre_upgrade_hook' is to provide this sort of tasks
before running an actual upgrade.