### PR TITLE
Extend 'execute' task with 'cwd' argument

### DIFF
--- a/kostyor/rpc/tasks/execute.py
+++ b/kostyor/rpc/tasks/execute.py
@@ -7,17 +7,18 @@ from kostyor.rpc.app import app
 
 
 @app.task(bind=True, base=AbortableTask)
-def execute(self, args, ignore_errors=False):
+def execute(self, args, cwd=None, ignore_errors=False):
     """Execute an arbitrary process and terminate it if abort() is sent.
 
     In case when process ended with return code non-equal to zero, the
     exception is raised in order to mark celery task as failed.
 
     :param args: process with arguments to be executed
+    :param cwd: path to current working directory to be set
     :param ignore_errors: do not raise exception for '!=0' return codes if True
     :return: process' return code, or 'None' if it was aborted
     """
-    process = subprocess.Popen(args)
+    process = subprocess.Popen(args, cwd=cwd)
 
     # Unfortunately, 'timeout' parameter of 'wait' method has been added in
     # Python 3.3, so we can't use to do a periodic check for 'is_aborted()'


### PR DESCRIPTION
It's usually very important to pass current working directory for
executables. For instance, OpenStack Ansible's 'bootstrap-ansible.sh'
script use current working directory to get a path to one of the
playbooks. Hence, if we run it programmatically and do not pass CWD that
points to /opt/openstack-ansible - the task will fail.